### PR TITLE
fix(diagramlink): populate `positionFrom` and `positionTo`

### DIFF
--- a/src/DiagramModel.js
+++ b/src/DiagramModel.js
@@ -68,8 +68,8 @@ class DiagramModel {
       id: generateId(),
       from: from,
       to: to,
-      positionFrom: {},
-      positionTo: {},
+      positionFrom: { x: 0, y: 0 },
+      positionTo: { x: 0, y: 0 },
       points
     });
   }


### PR DESCRIPTION
with `{x:0, y:0}` in DiagramModel.addLink(). To prevent error message when new link is created. As the link's curve cannot otherwise be drawn properly (as no `x` nor `y` yet defined for `positionFrom` and `positionTo`) until the first call to `updateLinksPositions()`.

Close #6
